### PR TITLE
Library namespace added [Closes #3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example:
 
  SEND SMS:
 ```PHP
-$sms = new SmsManager();
+$sms = new Stromaler\Biz123Sms\SmsManager();
 $sms->setSender('Me')
     ->setCredentials('myUsername','password')
     ->setMessage('Hi, this is test SMS')
@@ -29,14 +29,14 @@ $sms->setSender('Me')
  GET CREDIT INFORMATION:
 
 ```PHP
-$sms = new SmsManager();
+$sms = new Stromaler\Biz123Sms\SmsManager();
 $myCredit = $sms->setCredentials('myUsername','password')->getCredit();
 ```
 
  VERIFY NUMBER:
 
 ```PHP
-$sms = new SmsManager();
+$sms = new Stromaler\Biz123Sms\SmsManager();
 $numberInfo = $sms->setCredentials('myUsername','password')->verifyNumber('00421111222');
 ```
 The only dependency is CURL module in PHP.

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,12 @@
             "email": "stromajer.michal@gmail.com"
         }
     ],
+    "require": {
+        "php": ">= 5.3"
+    },
     "autoload": {
-        "classmap": ["src/"]
+        "psr-4": {
+            "Stromaler\\Biz123Sms\\": "src/"
+        }
     }
 }

--- a/src/SmsManager.php
+++ b/src/SmsManager.php
@@ -8,6 +8,7 @@
  * (c) 2015 Michal Stromajer <stromaler@gospace.sk>
  **/
 
+namespace Stromaler\Biz123Sms;
 
 class SmsManager
 {


### PR DESCRIPTION
Namespace requires PHP >= 5.3 and causes BC-break.

It's a proposal for v2.0 release.

NS avoids `SmsManager` name collision with others classes with the same name which have no NS too.
